### PR TITLE
Suggest to use RFC3339 for -f and -t options

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The **second part**, the __query description file__ defines the "what": what's m
   - __**RenameTags**__ defines the tag names that have to be renamed
 
 The **third part** defines all the parameters (command line) relative to a specific execution :
-- `-f` and `-t` (both required) defines the date range for the execution. The date format (UTC) is the following `YYYY-MM-DDThh:mm:ss.lllZ` where `YYYY` is the year, `MM` the month, `DD` the day, `hh` the hour, `mm` the minutes, `ss` the seconds and `lll` the milliseconds. Sample : `2019-07-31T17:03:00.000Z`.
+- `-f` and `-t` (both required) defines the date range for the execution. It supports RFC3339 date format.
+  - `YYYY-MM-DDThh:mm:ss.lllZ` where `YYYY` is the year, `MM` the month, `DD` the day, `hh` the hour, `mm` the minutes, `ss` the seconds, `lll` the milliseconds and `Z` UTC+0. Sample : `2019-07-31T17:03:00.000Z`.
+  - `YYYY-MM-DDThh:mm:ss.lll+09:00` or `YYYY-MM-DDThh:mm:ss.lll-04:00` where you can describe time-zone with `+xx:00` or `-yy:00`.
 - `-s` activates the simulation mode : data will be gathered from Prometheus, mapped as it should be for Opentsdb but it will not be sent but only printed. By default, simulation mode is disabled.
 
 But why such a configuration mechanism ? The objective is in fact :

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,8 +27,6 @@ const (
 	simuParamKey         string = "s"
 )
 
-const dateFormat string = "2006-01-02T15:04:05.000Z"
-
 const defaultLoggingLevel string = "info"
 
 var loggingLevels = map[string]logrus.Level{
@@ -101,11 +99,11 @@ func doMain(args []string) int {
 		return retConfFailure
 	}
 
-	if queryConf.Start, err = time.Parse(dateFormat, *fromParam); err != nil {
+	if queryConf.Start, err = time.Parse(time.RFC3339, *fromParam); err != nil {
 		logrus.Errorf("error while parsing start date (%v): %v", *fromParam, err)
 		return retConfFailure
 	}
-	if queryConf.End, err = time.Parse(dateFormat, *toParam); err != nil {
+	if queryConf.End, err = time.Parse(time.RFC3339, *toParam); err != nil {
 		logrus.Errorf("error while parsing end date (%v): %v", *toParam, err)
 		return retConfFailure
 	}


### PR DESCRIPTION
- About RFC3339 : https://medium.com/easyread/understanding-about-rfc-3339-for-datetime-formatting-in-software-engineering-940aa5d5f68a
- RFC3339 supports `2019-07-31T17:03:00.000Z` as it is.
- Time-zone can be specified like this `2019-07-31T20:03:00.000+03:00`.